### PR TITLE
Optional Config File Argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+parsdict_config.ini
+parsdict_logging.ini

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-__pycache__
-parsdict_config.ini
-parsdict_logging.ini

--- a/parsdict.py
+++ b/parsdict.py
@@ -72,6 +72,7 @@ def get_command_arguments():
     input      required, specifies data source, naming pattern url__ or file__
     output     optional, if provided a file of dictionary elements is created
                    -o, --output, this is all that needs to be specified if used
+    config     optional, if provided will serve as the config.ini location
     """
 
     parser = argparse.ArgumentParser('Search Game Data for Player Statistics')
@@ -94,8 +95,16 @@ def get_command_arguments():
         dest='output',
         action='store_true'
     )
+    parser.add_argument(
+        '-c,'
+        '--config',
+        help='Config file location',
+        dest='config',
+        type=str
+    )
 
     argue = parser.parse_args()
+
     # log command line arguments and if optional output file was chosen
     logger.info('parsdict arguments: ' + argue.last_name + ' ' + argue.input)
     if argue.output:
@@ -104,11 +113,29 @@ def get_command_arguments():
     return argue
 
 
-def get_json_location(jsonkey):
+def get_config_file(config_default, opt_config=None):
 
-    # get location from config file using command line argument as the key
     config = configparser.ConfigParser()
-    config.read(CONFIG_INI)
+
+    # override global variable if optional config location passed
+    if opt_config:
+        configini = opt_config
+    else:
+        configini = config_default
+
+    logger.info('Config file location = ' + configini)
+
+    try:
+        config.read_file(open(configini))
+        config.read(configini)
+        return config
+    except Exception as e:
+        logger.critical('Error loading configuration file. . .')
+        logger.exception(e)
+        return 1
+
+
+def get_json_location(jsonkey, config):
 
     # don't have proper Config paramater based on Command Line argument
     if jsonkey[:4] != 'file' and jsonkey[:3] != 'url':
@@ -168,7 +195,11 @@ def main():
 
     args = get_command_arguments()
 
-    jsonloc = get_json_location(args.input)
+    configdata = get_config_file(CONFIG_INI, args.config)
+    if configdata == 1:
+        return configdata
+
+    jsonloc = get_json_location(args.input, configdata)
     if jsonloc in (10, 11):
         return jsonloc
 

--- a/parsdict.py
+++ b/parsdict.py
@@ -117,7 +117,7 @@ def get_config_file(config_default, opt_config=None):
 
     config = configparser.ConfigParser()
 
-    # override global variable if optional config location passed
+    # override config location if optional command line argument specified
     if opt_config:
         configini = opt_config
     else:
@@ -125,6 +125,7 @@ def get_config_file(config_default, opt_config=None):
 
     logger.info('Config file location = ' + configini)
 
+    # open config file to verify existence, then read and return
     try:
         config.read_file(open(configini))
         config.read(configini)

--- a/parsdict_config_SAMPLE.ini
+++ b/parsdict_config_SAMPLE.ini
@@ -3,8 +3,8 @@
 # Only 1 entry will be used as input for any given run of the script parsdict.py
 # A command line argument provided at execution will point to one of the entries below
 # Two types of locations are able to be processed, a local file or a url address
-# Entries using a local file must start with the letters file
-# Entries using a url must start with the letters url
+# Entries using a local file must start with the letters 'file'
+# Entries using a url must start with the letters 'url'
 # All entries must be unique and can have any characters or numbers appended so that
 # several locations can be defined for the operator to choose from
 # Examples:


### PR DESCRIPTION
These changes provide an optional command line argument to specify a different config file location for use with parsdict.py