### PR TITLE
Adding some example tests.

### DIFF
--- a/tests/test_parsdict.py
+++ b/tests/test_parsdict.py
@@ -1,0 +1,32 @@
+# Tests for JSON Dictionary Parsing Program
+# Copyright 2017 Allan LeSage
+
+import unittest
+from unittest import mock
+
+import configparser
+
+import parsdict
+
+
+class GetJsonLocationTestCase(unittest.TestCase):
+
+    def test_jsonkey_gibberish_returns_10(self):
+        result = parsdict.get_json_location('gibberish', 'fake_config')
+        self.assertEqual(10, result)
+
+    @mock.patch.object(configparser.ConfigParser, 'has_option')
+    def test_datasources_missing(self, has_option):
+        has_option.return_value = False
+        mock_config = configparser.ConfigParser()
+        result = parsdict.get_json_location('url', mock_config)
+        self.assertEqual(11, result)
+
+    @mock.patch.object(configparser.ConfigParser, 'get')
+    @mock.patch.object(configparser.ConfigParser, 'has_option')
+    def test_datasources_vanilla(self, has_option, get):
+        has_option.return_value = True
+        get.return_value = 'fake_location'
+        mock_config = configparser.ConfigParser()
+        result = parsdict.get_json_location('url', mock_config)
+        self.assertEqual('fake_location', result)


### PR DESCRIPTION
These wound up being complicated due to the use of the configparser, but don't worry we'll go over :) .

To try the tests I'm using (will have to pip install nose):
`python -m nose --with-coverage --cover-html --cover-package=.`

Then have a look in the "cover" dir for an html output of your test coverage :) .