### PR TITLE
Trying out internal exceptions instead of return codes.

### DIFF
--- a/tests/test_parsdict.py
+++ b/tests/test_parsdict.py
@@ -12,15 +12,15 @@ import parsdict
 class GetJsonLocationTestCase(unittest.TestCase):
 
     def test_jsonkey_gibberish_returns_10(self):
-        result = parsdict.get_json_location('gibberish', 'fake_config')
-        self.assertEqual(10, result)
+        with self.assertRaises(parsdict.JsonLocationKeyError):
+            parsdict.get_json_location('gibberish', 'fake_config')
 
     @mock.patch.object(configparser.ConfigParser, 'has_option')
     def test_datasources_missing(self, has_option):
         has_option.return_value = False
         mock_config = configparser.ConfigParser()
-        result = parsdict.get_json_location('url', mock_config)
-        self.assertEqual(11, result)
+        with self.assertRaises(parsdict.JsonKeyMissingError):
+            parsdict.get_json_location('url', mock_config)
 
     @mock.patch.object(configparser.ConfigParser, 'get')
     @mock.patch.object(configparser.ConfigParser, 'has_option')


### PR DESCRIPTION
Was thinking about this yesterday and think this is a little cleaner, else someone using the parsdict module could believe that 10 or 11 are sensible locations, which I see that we're handling, but still. . . .  What do you think?